### PR TITLE
Rename Screensaver to “Matrix”

### DIFF
--- a/Web.saver/Contents/Info.plist
+++ b/Web.saver/Contents/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Web</string>
+	<string>Matrix</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
fixes #1
