### PR TITLE
Use high resolution canvas on hi-dpi displays

### DIFF
--- a/Web.saver/Contents/Resources/matrix.js
+++ b/Web.saver/Contents/Resources/matrix.js
@@ -6,8 +6,20 @@
     var canvas = document.getElementById("matrix");
 
     // fullscreen canvas
-    canvas.height = window.innerHeight;
-    canvas.width = window.innerWidth;
+    if (window.devicePixelRatio && window.devicePixelRatio > 1) {
+        // Use higher resolution on retina displays
+        var canvasWidth = window.innerWidth;
+        var canvasHeight = window.innerHeight;
+
+        canvas.width = canvasWidth * window.devicePixelRatio;
+        canvas.height = canvasHeight * window.devicePixelRatio;
+        canvas.style.width = canvasWidth + "px";
+        canvas.style.height = canvasHeight + "px";
+        canvas.getContext('2d').scale(window.devicePixelRatio, window.devicePixelRatio);
+    } else {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+    }
 
     var Pool = function (size) {
         var data = [];


### PR DESCRIPTION
I am using the screensaver on a 5K-iMac and it always looked a bit blurry. So I made a small adjustment that enabled retina resolution of the canvas on hi-dpi displays. It now look gorgeous on the iMac. 👍 
